### PR TITLE
feat: Add log_analytics_workspace_daily_quota_gb variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+Added
+ * [GITHUB-2](https://github.com/claranet/terraform-azurerm-run/pull/2): Add `log_analytics_workspace_daily_quota_gb` variable
+
+Fixed
+ * [GITHUB-2](https://github.com/claranet/terraform-azurerm-run/pull/2): Lookup with 2 arguments is deprecated (terraform_deprecated_lookup)
+
 # v7.6.3 - 2023-10-20
 
 Changed

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ module "run" {
 | location\_short | Short string for Azure location. | `string` | n/a | yes |
 | log\_analytics\_resource\_group\_name | Log Analytics Workspace resource group name (if different from `resource_group_name` variable.). | `string` | `null` | no |
 | log\_analytics\_workspace\_custom\_name | Azure Log Analytics Workspace custom name. Empty by default, using naming convention. | `string` | `""` | no |
+| log\_analytics\_workspace\_daily\_quota\_gb | The workspace daily quota for ingestion in GB. Defaults to -1 (unlimited). | `number` | `-1` | no |
 | log\_analytics\_workspace\_extra\_tags | Extra tags to add to the Log Analytics Workspace | `map(string)` | `{}` | no |
 | log\_analytics\_workspace\_id | Log Analytics Workspace ID where the logs are sent and linked to Automation account. | `string` | `null` | no |
 | log\_analytics\_workspace\_link\_enabled | Enable Log Analytics Workspace that will be connected with the automation account. | `bool` | `true` | no |

--- a/m-logs.tf
+++ b/m-logs.tf
@@ -26,12 +26,12 @@ module "logs" {
   logs_storage_account_enable_archived_logs_fileshare    = var.logs_storage_account_enable_archived_logs_fileshare
   logs_storage_account_archived_logs_fileshare_name      = var.logs_storage_account_archived_logs_fileshare_name
   logs_storage_account_archived_logs_fileshare_quota     = var.logs_storage_account_archived_logs_fileshare_quota
-
-  log_analytics_workspace_name_prefix       = var.log_analytics_workspace_name_prefix
-  log_analytics_workspace_custom_name       = var.log_analytics_workspace_custom_name
-  log_analytics_workspace_extra_tags        = var.log_analytics_workspace_extra_tags
-  log_analytics_workspace_retention_in_days = var.log_analytics_workspace_retention_in_days
-  log_analytics_workspace_sku               = var.log_analytics_workspace_sku
+  log_analytics_workspace_name_prefix                    = var.log_analytics_workspace_name_prefix
+  log_analytics_workspace_custom_name                    = var.log_analytics_workspace_custom_name
+  log_analytics_workspace_extra_tags                     = var.log_analytics_workspace_extra_tags
+  log_analytics_workspace_retention_in_days              = var.log_analytics_workspace_retention_in_days
+  log_analytics_workspace_daily_quota_gb                 = var.log_analytics_workspace_daily_quota_gb
+  log_analytics_workspace_sku                            = var.log_analytics_workspace_sku
 
   logs_storage_account_enable_archiving                      = var.logs_storage_account_enable_archiving
   tier_to_cool_after_days_since_modification_greater_than    = var.logs_tier_to_cool_after_days_since_modification_greater_than

--- a/modules/automation-account/locals-tags.tf
+++ b/modules/automation-account/locals-tags.tf
@@ -8,12 +8,12 @@ locals {
 
   # Automation Account Azure resource can have only 15 tags maximum
   truncated_tags = {
-    for key in try(chunklist(keys(local.merged_tags), 14)[0], []) : key => lookup(local.merged_tags, key)
+    for key in try(chunklist(keys(local.merged_tags), 14)[0], []) : key => local.merged_tags[key]
   }
 
   # We keep the 14 first tags, serialize all the others in a 15th one (JSON encoded)
   curtailed_tags = merge(
     local.truncated_tags,
-    try({ "extra_tags" = jsonencode({ for key in slice(keys(local.merged_tags), 14, length(local.merged_tags)) : key => lookup(local.merged_tags, key) }) }, {})
+    try({ "extra_tags" = jsonencode({ for key in slice(keys(local.merged_tags), 14, length(local.merged_tags)) : key => local.merged_tags[key] }) }, {})
   )
 }

--- a/modules/logs/README.md
+++ b/modules/logs/README.md
@@ -112,6 +112,7 @@ module "logs" {
 | log\_analytics\_workspace\_extra\_tags | Extra tags to add to the Log Analytics Workspace | `map(string)` | `{}` | no |
 | log\_analytics\_workspace\_name\_prefix | Log Analytics name prefix | `string` | `""` | no |
 | log\_analytics\_workspace\_retention\_in\_days | The workspace data retention in days. Possible values range between 30 and 730. | `number` | `30` | no |
+| log\_analytics\_workspace\_daily\_quota\_gb | The workspace daily quota for ingestion in GB. Defaults to -1 (unlimited). | `number` | `-1` | no |
 | log\_analytics\_workspace\_sku | Specifies the SKU of the Log Analytics Workspace. Possible values are Free, PerNode, Premium, Standard, Standalone, Unlimited, and PerGB2018 (new Sku as of 2018-04-03). | `string` | `"PerGB2018"` | no |
 | logs\_storage\_account\_access\_tier | Defines the access tier for `BlobStorage`, `FileStorage` and `StorageV2` accounts. Valid options are `Hot` and `Cool`, defaults to `Hot`. | `string` | `"Hot"` | no |
 | logs\_storage\_account\_archived\_logs\_fileshare\_name | Name of the file share in which externalized logs are stored | `string` | `"archived-logs"` | no |

--- a/modules/logs/README.md
+++ b/modules/logs/README.md
@@ -109,10 +109,10 @@ module "logs" {
 | location | Azure location. | `string` | n/a | yes |
 | location\_short | Short string for Azure location. | `string` | n/a | yes |
 | log\_analytics\_workspace\_custom\_name | Azure Log Analytics Workspace custom name. Empty by default, using naming convention. | `string` | `""` | no |
+| log\_analytics\_workspace\_daily\_quota\_gb | The workspace daily quota for ingestion in GB. Defaults to -1 (unlimited). | `number` | `-1` | no |
 | log\_analytics\_workspace\_extra\_tags | Extra tags to add to the Log Analytics Workspace | `map(string)` | `{}` | no |
 | log\_analytics\_workspace\_name\_prefix | Log Analytics name prefix | `string` | `""` | no |
 | log\_analytics\_workspace\_retention\_in\_days | The workspace data retention in days. Possible values range between 30 and 730. | `number` | `30` | no |
-| log\_analytics\_workspace\_daily\_quota\_gb | The workspace daily quota for ingestion in GB. Defaults to -1 (unlimited). | `number` | `-1` | no |
 | log\_analytics\_workspace\_sku | Specifies the SKU of the Log Analytics Workspace. Possible values are Free, PerNode, Premium, Standard, Standalone, Unlimited, and PerGB2018 (new Sku as of 2018-04-03). | `string` | `"PerGB2018"` | no |
 | logs\_storage\_account\_access\_tier | Defines the access tier for `BlobStorage`, `FileStorage` and `StorageV2` accounts. Valid options are `Hot` and `Cool`, defaults to `Hot`. | `string` | `"Hot"` | no |
 | logs\_storage\_account\_archived\_logs\_fileshare\_name | Name of the file share in which externalized logs are stored | `string` | `"archived-logs"` | no |

--- a/modules/logs/r-logs.tf
+++ b/modules/logs/r-logs.tf
@@ -9,6 +9,7 @@ resource "azurerm_log_analytics_workspace" "log_workspace" {
 
   sku               = var.log_analytics_workspace_sku
   retention_in_days = var.log_analytics_workspace_retention_in_days
+  daily_quota_gb    = var.log_analytics_workspace_daily_quota_gb
 
   tags = merge(
     local.default_tags,

--- a/modules/logs/variables.tf
+++ b/modules/logs/variables.tf
@@ -46,6 +46,12 @@ variable "log_analytics_workspace_retention_in_days" {
   default     = 30
 }
 
+variable "log_analytics_workspace_daily_quota_gb" {
+  description = "The workspace daily quota for ingestion in GB. Defaults to -1 (unlimited)."
+  type        = number
+  default     = -1
+}
+
 variable "logs_storage_account_enabled" {
   description = "Whether the dedicated Storage Account for logs is created."
   type        = bool

--- a/variables-log-analytics.tf
+++ b/variables-log-analytics.tf
@@ -31,6 +31,12 @@ variable "log_analytics_workspace_retention_in_days" {
   default     = 30
 }
 
+variable "log_analytics_workspace_daily_quota_gb" {
+  description = "The workspace daily quota for ingestion in GB. Defaults to -1 (unlimited)."
+  type        = number
+  default     = -1
+}
+
 variable "logs_storage_account_enabled" {
   description = "Whether the dedicated Storage Account for logs is created."
   type        = bool


### PR DESCRIPTION
Enables the logs module users to adjust `daily_quota_gb`
property of `azurerm_log_analytics_workspace` resource.

Closes #1
